### PR TITLE
RTC initialization fix and DSE feature rollback

### DIFF
--- a/config.inc
+++ b/config.inc
@@ -22,7 +22,7 @@
 ;
 ;=========================================================================
 
-%define DATE		'09/25/19'	; BIOS release date MM/DD/YY
+%define DATE		'10/17/19'	; BIOS release date MM/DD/YY
 %define VERSION		'0.9.7'		; BIOS version
 
 ; Machine type is defined in the Makefile

--- a/messages.inc
+++ b/messages.inc
@@ -113,11 +113,10 @@ msg_set_help	db	0Dh, 0Ah
 %ifdef TURBO_MODE
 		db	'c - Set default CPU clock frequency', 0Dh, 0Ah
 %endif ; TURBO_MODE
-%ifdef AT_RTC
-		db	't - Set time', 0Dh, 0Ah
-		db	'd - Set date', 0Dh, 0Ah
-%endif ; AT_RTC
-		db	'f - Change first floppy drive type', 0Dh, 0Ah
+		db 00h
+msg_set_help_rtc	db	't - Set time', 0Dh, 0Ah
+		db	'd - Set date', 0Dh, 0Ah, 00h
+msg_set_help_2	db	'f - Change first floppy drive type', 0Dh, 0Ah
 		db	'g - Change second floppy drive type', 0Dh, 0Ah
 		db	'e - Change BIOS extension ROM scan settings', 0Dh, 0Ah
 		db	'p - Print current settings', 0Dh, 0Ah

--- a/messages.inc
+++ b/messages.inc
@@ -100,7 +100,6 @@ msg_rom_init	db	'0, initializing...', 0Dh, 0Ah, 0
 msg_boot	db      'Booting OS...', 0Dh, 0Ah, 0
 %ifdef AT_RTC
 msg_rtc_bad	db	'ERROR: RTC battery is bad', 0Dh, 0Ah, 00h
-msg_rtc_dse	db	' Daylight saving ', 00h
 %endif ; AT_RTC
 %ifdef AT_RTC_NVRAM
 msg_rtc_sum	db	'ERROR: NVRAM checksum is invalid, '
@@ -117,7 +116,6 @@ msg_set_help	db	0Dh, 0Ah
 %ifdef AT_RTC
 		db	't - Set time', 0Dh, 0Ah
 		db	'd - Set date', 0Dh, 0Ah
-		db	's - Change daylight saving', 0Dh, 0Ah
 %endif ; AT_RTC
 		db	'f - Change first floppy drive type', 0Dh, 0Ah
 		db	'g - Change second floppy drive type', 0Dh, 0Ah
@@ -143,7 +141,6 @@ msg_set_clk_prmt db	0Dh, 0Ah, 'Enter CPU clock frequency (h for help): '
 %ifdef AT_RTC
 msg_set_time	db	'Enter time (hh:mm:ss): ', 00h
 msg_set_date	db	'Enter date (YYYY-MM-DD): ', 00h
-msg_set_dse	db	'Enable daylight saving (y/n): ',00h
 msg_time_inval	db	'ERROR: Invalid time.', 0Dh, 0Ah, 00h
 msg_date_inval	db	'ERROR: Invalid date.', 0Dh, 0Ah, 00h
 %endif ; AT_RTC

--- a/rtc.inc
+++ b/rtc.inc
@@ -106,61 +106,16 @@ rtc_write:
 	ret
 
 ;=========================================================================
-; rtc_init - Initialize RTC
-; Notes:
-;	- makes sure RTC battery is OK, resets time if not
-;	- disables RTC interrupts
-;	- validates NVRAM checksum, loads default values if invalid
+; set_system_timer - set timer variables to RTC time
 ;-------------------------------------------------------------------------
-rtc_init:
+set_system_timer:
 	push	ax
 	push	bx
 	push	cx
 	push	dx
 	push	si
 	push	di
-	mov	al,cmos_control_a	; select control A register
-	mov	ah,26h			; turn on oscillator and time keeping
-					; set SQW frequency to 1.024 KHz
-	call	rtc_write		; write control register A
 
-%ifdef AT_RTC_AUTODETECT
-	call	rtc_read		; read back control A register
-	cmp	al,26h
-	jne	.exit			; RTC is not responding, exit
-%endif ; AT_RTC_AUTODETECT
-
-	mov	al,cmos_control_b
-	call	rtc_read
-	mov	ah,al
-	and	ah,cmos_dse		; clear all bits except of DSE
-	or	ah,cmos_24hours		; set 24 hours bit, keep BCD format and
-					; interrupts disabled
-	mov	al,cmos_control_b
-	call	rtc_write		; write control register B
-
-	mov	al,cmos_control_c
-	call	rtc_read		; read control register C - reset
-					; interrupt flags
-
-	mov	al,cmos_control_d
-	call	rtc_read		; read control register D
-	test	al,cmos_vrt
-	jnz	.1			; RTC battery is OK
-	mov	si,msg_rtc_bad
-	call	print
-; RTC is bad, set initial time
-	mov	ah,03h			; int 1Ah, function 03h - set RTC time
-	xor	cx,cx
-	xor	dx,dx
-	int	1Ah
-	mov	ah,05h			; int 1Ah, function 05h - set RTC date
-	mov	cx,2010h		; year 2010
-	mov	dx,0101h		; January 1st
-	int	1Ah
-
-.1:
-; set timer variables to RTC time
 	mov	ah,02h			; int 1Ah, function 02h - get RTC time
 	int	1Ah
 
@@ -227,7 +182,70 @@ rtc_init:
 	
 	mov	ah,01h			; int 1Ah, function 01h - set time
 	int	1Ah
+	pop	di
+	pop	si
+	pop	dx
+	pop	cx
+	pop	bx
+	pop	ax
+	ret
 
+;=========================================================================
+; rtc_init - Initialize RTC
+; Notes:
+;	- makes sure RTC battery is OK, resets time if not
+;	- disables RTC interrupts
+;	- validates NVRAM checksum, loads default values if invalid
+;-------------------------------------------------------------------------
+rtc_init:
+	push	ax
+	push	bx
+	push	cx
+	push	dx
+	push	si
+	mov	al,cmos_control_a	; select control A register
+	mov	ah,26h			; turn on oscillator and time keeping
+					; set SQW frequency to 1.024 KHz
+	call	rtc_write		; write control register A
+
+%ifdef AT_RTC_AUTODETECT
+	call	rtc_read		; read back control A register
+	cmp	al,26h
+	jne	.exit			; RTC is not responding, exit
+%endif ; AT_RTC_AUTODETECT
+
+	mov	al,cmos_control_b
+	call	rtc_read
+	mov	ah,al
+	and	ah,cmos_dse		; clear all bits except of DSE
+	or	ah,cmos_24hours		; set 24 hours bit, keep BCD format and
+					; interrupts disabled
+	mov	al,cmos_control_b
+	call	rtc_write		; write control register B
+
+	mov	al,cmos_control_c
+	call	rtc_read		; read control register C - reset
+					; interrupt flags
+
+	mov	al,cmos_control_d
+	call	rtc_read		; read control register D
+	test	al,cmos_vrt
+	jnz	.1			; RTC battery is OK
+	mov	si,msg_rtc_bad
+	call	print
+; RTC is bad, set initial time
+	mov	ah,03h			; int 1Ah, function 03h - set RTC time
+	xor	cx,cx
+	xor	dx,dx
+	int	1Ah
+	mov	ah,05h			; int 1Ah, function 05h - set RTC date
+	mov	cx,2010h		; year 2010
+	mov	dx,0101h		; January 1st
+	int	1Ah
+
+.1:
+
+	call	set_system_timer		; set timer variables to RTC time
 
 %ifdef AT_RTC_NVRAM
 ; compare NVRAM checksum with stored value
@@ -289,7 +307,6 @@ rtc_init:
 %endif ; AT_RTC_NVRAM
 
 .exit:
-	pop	di
 	pop	si
 	pop	dx
 	pop	cx
@@ -497,19 +514,9 @@ print_rtc:
 	mov	al,dh
 	call	print_byte		; print 2-digit seconds
 
-	mov	si,msg_rtc_dse
-	call	print
-	mov	si,msg_disabled		; assume DSE disabled
-	cmp	dl,0
-	je	.dse_print
-	mov	si,msg_enabled		; DSE enabled
-
-.dse_print:
-	call	print
+.exit:
 	mov	si,msg_crlf
 	call	print
-
-.exit:
 	pop	si
 	pop	dx
 	pop	cx

--- a/rtc.inc
+++ b/rtc.inc
@@ -513,10 +513,10 @@ print_rtc:
 
 	mov	al,dh
 	call	print_byte		; print 2-digit seconds
-
-.exit:
 	mov	si,msg_crlf
 	call	print
+
+.exit:
 	pop	si
 	pop	dx
 	pop	cx

--- a/rtc.inc
+++ b/rtc.inc
@@ -302,7 +302,7 @@ rtc_init:
 	and	byte [equipment_list],equip_video|equip_mouse
 	or	byte [equipment_list],al
 
-	mov	al,e_rtc_init_ok	; RTC initialzied successfully
+	mov	al,e_rtc_init_ok	; RTC initialized successfully
 	out	post_reg,al
 %endif ; AT_RTC_NVRAM
 
@@ -462,7 +462,7 @@ print_rtc:
 	call	print
 	jmp	.exit
 .rtc_present:
-%endif ; AT_RTC_AUTODETCT
+%endif ; AT_RTC_AUTODETECT
 
 ; print date
 	mov	ah,04h

--- a/setup.inc
+++ b/setup.inc
@@ -82,8 +82,6 @@ nvram_setup:
 	je	.set_time
 	cmp	al,'d'
 	je	.set_date
-	cmp	al,'s'
-	je	.set_daylight_saving
 	cmp	al,'e'
 	je	.set_ext_scan
 %endif ; AT_RTC
@@ -343,6 +341,7 @@ nvram_setup:
 
 	mov	ah,03h			; set RTC time
 	int	1Ah
+	call	set_system_timer		; set timer variables to RTC time
 
 .set_time_exit:
 	pop	es
@@ -482,62 +481,6 @@ nvram_setup:
 	mov	si,msg_date_inval
 	call	print
 	jmp	.set_date_exit
-
-.set_daylight_saving:
-	push	cx
-	push	di
-	push	es
-	mov	ah,0Eh			; echo
-	mov	bx,0007h
-	int	10h
-	mov	si,msg_crlf
-	call	print
-	mov	si,msg_set_dse
-	call	print
-
-.set_dse_input:
-	mov	ah,00h
-	int	16h
-	cmp	al,0Dh
-	je	.set_dse_exit
-	or	al,20h			; convert to lower case
-	cmp	al,'n'
-	je	.set_dse_disable
-	cmp	al,'y'
-	je	.set_dse_enable
-	jmp	.set_dse_input
-
-.set_dse_disable:
-	mov	ah,0Eh			; echo
-	mov	bx,0007h
-	int	10h
-	mov	al,cmos_control_b
-	call	rtc_read
-	mov	ah,al
-	and	ah,~cmos_dse		; clear DSE bit
-	mov	al,cmos_control_b
-	call	rtc_write
-	jmp	.set_dse_exit
-
-.set_dse_enable:
-	mov	ah,0Eh			; echo
-	mov	bx,0007h
-	int	10h
-	mov	al,cmos_control_b
-	call	rtc_read
-	mov	ah,al
-	or	ah,cmos_dse		; set DSE bit
-	mov	al,cmos_control_b
-	call	rtc_write
-	jmp	.set_dse_exit
-
-.set_dse_exit:
-	mov	si,msg_crlf
-	call	print
-	pop	es
-	pop	di
-	pop	cx
-	jmp	.menu_loop
 
 %endif ; AT_RTC
 

--- a/setup.inc
+++ b/setup.inc
@@ -35,6 +35,27 @@ nvram_ext_scan	equ	04h		; F0000-F7FFF BIOS extension scan bit
 					; (0 - enabled, 1 - disabled)
 %endif ; AT_RTC_NVRAM or FLASH_NVRAM
 
+help_msg_fn:
+	mov	si,msg_set_help
+	call	print
+
+%ifdef AT_RTC
+	
+	%ifdef AT_RTC_AUTODETECT
+		call	rtc_detect
+		jc	.rtc_absent
+	%endif ; AT_RTC_AUTODETECT
+
+	mov	si,msg_set_help_rtc
+	call	print
+
+.rtc_absent:
+%endif ; AT_RTC
+
+	mov	si,msg_set_help_2
+	call	print
+	ret
+
 ;=========================================================================
 ; nvram_setup - NVRAM configuration utility
 ; Input:
@@ -78,13 +99,19 @@ nvram_setup:
 	je	.set_cpu_clk
 %endif ; TURBO_MODE
 %ifdef AT_RTC
+	%ifdef AT_RTC_AUTODETECT
+		call	rtc_detect
+		jc	.rtc_absent_2
+	%endif ; AT_RTC_AUTODETECT
 	cmp	al,'t'
 	je	.set_time
 	cmp	al,'d'
 	je	.set_date
+	
+.rtc_absent_2:
+%endif ; AT_RTC
 	cmp	al,'e'
 	je	.set_ext_scan
-%endif ; AT_RTC
 	cmp	al,'w'
 	je	.save
 	cmp	al,'q'
@@ -97,8 +124,7 @@ nvram_setup:
 	mov	ah,0Eh			; echo
 	mov	bx,0007h
 	int	10h
-	mov	si,msg_set_help
-	call	print
+	call help_msg_fn
 	jmp	.menu_loop
 
 .set_floppy:


### PR DESCRIPTION
When time is update from setup, the system timer (INT 1Ah/AH=01h) were not updated, I fixed it.

The DSE feature is no longer used, seeing the incompatibility of the DS12885/7 RTC chip with certain countries.