### PR TITLE
Fixes for MACHINE_XT build

### DIFF
--- a/bios.asm
+++ b/bios.asm
@@ -1001,7 +1001,7 @@ low_ram_ok:
 	and	al,0FDh		; clear switch select bit - select SW5-SW8
 %endif ; MACHINE_FE2010A
 %ifdef MACHINE_XT
-	and	al,0F7h		; clear switch select bit - select SW5-SW8
+	or	al,08h		; set switch select bit - select SW5-SW8
 %endif ; MACHINE_XT
 	out	ppi_pb_reg,al
 	in	al,ppi_pc_reg	; read switches SW5-SW8
@@ -1281,7 +1281,8 @@ config_table:
 detect_rom_ext:
 	mov	al,e_ext_start		; ROM extension scan start
 	out	post_reg,al
-
+	in	al,pic1_reg1		; get IMR (option ROMs may trash it)
+	push	ax			; save it
 	mov	dx,0C800h
 	mov	bx,0F800h
 %ifdef AT_RTC_NVRAM or FLASH_NVRAM
@@ -1315,6 +1316,8 @@ detect_rom_ext:
 	jmp	.ext_scan_loop
 
 .ext_scan_done:
+	pop	ax			; get previous IMR
+	out	pic1_reg1,al		; restore it
 	mov	al,e_ext_complete	; ROM extension scan complete
 	out	post_reg,al
 

--- a/video.inc
+++ b/video.inc
@@ -200,13 +200,16 @@ int_10_fn00:
 					; assume CGA mode
 	mov	cx,0B800h		; CGA video memory segment
 	mov	dx,3D4h			; port for MC6845 CRTC address register
+	mov	al,byte [equipment_list] ; get equipment - low byte
+	and	al,equip_video		; get video adapter type
+	cmp	al,equip_mono		; monochrome?
 	mov	al,0
-	cmp	bl,07h
-	jb	.color			; jump if CGA/color mode
+	jne	.color			; jump if CGA/color mode
 					; set MDA mode
+	mov	bl,07h			; MDA can only be 7
 	mov	ch,0B0h			; MDA video memory segment
 	mov	dl,0B4h 		; port for MC6845 CRTC address register
-	inc	al
+	inc	ax
 
 .color:
 	mov	es,cx			; ES = video memory segment


### PR DESCRIPTION
Fixes a few small issues for IBM PC/XT build:

1. Standard PPI equipment switch is `1` to read SW5-8 (opposite of FE2010A).
2. Some option ROMs can trash IMR (including IBM Xebec FD controller). Preserve and restore after ROM scan.
3. MDA can only be video mode 7. Some "badly behaved" programs may attempt to change to a video mode other than 7 with MDA installed (causing what appears to be a crash).