### PR TITLE
Update video row count upon setting the video mode

### DIFF
--- a/src/video.inc
+++ b/src/video.inc
@@ -280,6 +280,8 @@ int_10_fn00:
 
     cs	mov	al,byte [bx+columns]	; Get display width
 	mov	word [video_columns],ax	;  ...save it
+	mov	al,24			; All supported modes have 25 rows
+	mov	byte [video_rows],al	;  ... the value saved uses one less
 	and	bl,0FEh			; Clear the LSB to get an index
 					; to 16-bit word page_size table
 					; FIXME: It returns graphics mode page


### PR DESCRIPTION
Memory location 0040h:0084h is described in RBIL as `VIDEO (EGA/MCGA/VGA) - ROWS ON SCREEN MINUS ONE`. It is referred to as `video_rows` in the 8088_bios source code.

It turns out this value is never set, and thus is always zero. This causes strange behaviour when installing FreeDOS, since VECHO.COM (part of V8POWER tools) uses this field during initialization to determine how to scroll the screen (`BasicInitialize` in`common.inc`). As this value is zero, it will end up overwriting the same line.

8088_bios only seems to support video modes of either 40x25 or 80x25, so simply setting `video_rows` to 24 is sufficient.