### PR TITLE
delay_15us implementation using PIT polling

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -70,6 +70,7 @@
 %define MIN_RAM_SIZE	32		; At least 32 KiB to boot the system
 %define MAX_RAM_SIZE	640		; Scan this much memory during POST
 %define RAM_TEST_BLOCK	16384		; block size for RAM test
+%define PIT_DELAY			; Use PIT polling for delays
 %endif ; MACHINE_BOOK8088
 
 ; Settings for IBM PC/XT
@@ -80,6 +81,7 @@
 %define MIN_RAM_SIZE	32		; At least 32 KiB to boot the system
 %define MAX_RAM_SIZE	640		; Scan this much memory during POST
 %define RAM_TEST_BLOCK	16384		; block size for RAM test
+%define PIT_DELAY			; Use PIT polling for delays
 %endif ; MACHINE_XT
 
 ; Automatic settings based on the machine settings above

--- a/src/delay.inc
+++ b/src/delay.inc
@@ -55,6 +55,67 @@ delay_15us:
 	ret
 
 %else ; AT_DELAY
+%ifdef PIT_DELAY
+
+;=========================================================================
+; delay_15us - delay for multiplies of 15 microseconds using PIT
+; Input:
+;	CX = time to delay (in 15 microsecond units)
+;
+; - Calculate the total number of PIT ticks necessary
+;	1,193,182 / 1000 ms / 1000 us / * 15 us * 2 = ~ 36 ticks/us
+; - Latch the PIT and draw down the countdown total on each read.
+; - Exit when countdown underflows.
+;
+; Note: Mode 3 (Square Wave) decements the readable counter by 2, so the
+; effective frequency of the counter is actually 2,386,360 Hz.
+;
+; Contributed by @640-KB (under GPL-3.0 license)
+; Based on contribution by @Raffzahn (under CC BY-SA 4.0):
+; https://retrocomputing.stackexchange.com/a/24874/21323
+;-------------------------------------------------------------------------
+delay_15us:
+	push	ax
+	push	bx
+	push	cx
+	push	dx
+	mov	bx,2*15*pic_freq/1000/1000+1	; ~ 36 ticks/us
+	xchg	ax,cx		; ax = wait in 15 microsecond increments
+	mul	bx		; dx:ax = countdown of pit ticks to wait
+	xchg	ax,bx		; dx:bx = countdown ticks
+	call	io_wait_latch	; ax = start read
+	mov	cx,ax		; cx = last read
+.tick_loop:
+	call	io_wait_latch	; ax = current counter reading
+	sub	cx,ax		; cx = # of ticks elapsed since last reading
+	sub	bx,cx		; subtract change in ticks from countdown
+	mov	cx,ax		; cx = save the last read
+	sbb	dx,0		; borrow out of high word (if necessary)
+	jae	.tick_loop	; loop while countdown >= 0
+	pop	dx
+	pop	cx
+	pop	bx
+	pop	ax
+	ret
+
+;=========================================================================
+; Latch PIT 0 and read counter
+; Output:
+;	AX = current counter
+;-------------------------------------------------------------------------
+io_wait_latch:
+	mov	al,0		; counter 0, latch (00b)
+	pushf			; save current IF
+	cli			; disable interrupts
+	out	pit_ctl_reg,al	; write command to ctc
+	in	al,pit_ch0_reg	; read low byte of counter 0 latch
+	mov	ah,al		; save it
+	in	al,pit_ch0_reg	; read high byte of counter 0 latch
+	popf			; restore IF state
+	xchg	al,ah		; convert endian
+	ret
+
+%else ; LOOP_DELAY
 
 ;=========================================================================
 ; delay_15us - delay for multiplies of approximately 15 microseconds
@@ -77,8 +138,8 @@ delay_15us:
 	pop	ax
 	ret
 
+%endif ; PIT_DELAY
 %endif ; AT_DELAY
-
 
 %if 0
 ;=========================================================================

--- a/src/delay.inc
+++ b/src/delay.inc
@@ -79,9 +79,8 @@ delay_15us:
 	push	bx
 	push	cx
 	push	dx
-	mov	bx,2*15*pic_freq/1000/1000+1	; ~ 36 ticks/us
-	xchg	ax,cx		; ax = wait in 15 microsecond increments
-	mul	bx		; dx:ax = countdown of pit ticks to wait
+	mov	ax,2*15*pic_freq/1000/1000+1	; ~ 36 ticks/us	
+	mul	cx		; dx:ax = countdown of pit ticks to wait
 	xchg	ax,bx		; dx:bx = countdown ticks
 	call	io_wait_latch	; ax = start read
 	mov	cx,ax		; cx = last read


### PR DESCRIPTION
Here is an alternate implementation of `delay_15us` that polls the PIT counters for accurate delays that will work on non-AT systems.  This may address https://github.com/skiselev/8088_bios/issues/50 and is in response to your https://github.com/skiselev/8088_bios/issues/50#issuecomment-1737737022. :)

Note: This is the (slightly modified) code I've used in GLaBIOS for such delays, so it is pretty well-tested.  However, you'll want to give it a good amount of actual testing within your own codebase for sure.