### PR TITLE
Initial support for HB8088 mainboard

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -46,6 +46,9 @@ bios-book8088.bin: $(SOURCES)
 bios-xt.bin: $(SOURCES)
 	nasm -DMACHINE_XT -O9 -f bin -o bios-xt.bin -l bios-xt.lst bios.asm
 
+bios-homebrew8088.bin: $(SOURCES)
+	nasm -DMACHINE_HOMEBREW8088 -O9 -f bin -o bios-homebrew8088.bin -l bios-homebrew8088.lst bios.asm
+
 bios-micro8088-noide.rom: bios-micro8088.bin
 	dd if=/dev/zero ibs=1k count=40 | LANG=C tr "\000" "\377" > bios-micro8088-noide.rom
 	cat bios-micro8088.bin >> bios-micro8088-noide.rom
@@ -89,7 +92,7 @@ bios-book8088-xtide-v20.rom: bios-book8088.bin $(XTIDE_300_V20)
 	cat bios-book8088.bin >> bios-book8088-xtide-v20.rom
 
 clean:
-	rm -f bios-micro8088.lst bios-xi8088.lst bios-book8088.lst bios-xt.lst bios-micro8088.bin bios-xi8088.bin bios-book8088.bin bios-xt.bin $(IMAGES)
+	rm -f bios-micro8088.lst bios-xi8088.lst bios-book8088.lst bios-xt.lst bios-homebrew8088.lst bios-micro8088.bin bios-xi8088.bin bios-book8088.bin bios-xt.bin  bios-homebrew8088.bin $(IMAGES)
 
 flash-micro8088:
 	minipro -p $(FLASH_ROM) -w bios-micro8088-xtide.rom

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -39,6 +39,10 @@ bios-book8088.bin: $(SOURCES)
 bios-xt.bin: $(SOURCES)
 	nasm -DMACHINE_XT -O9 -f bin -o bios-xt.bin -l bios-xt.lst bios.asm
 
+bios-homebrew8088.bin: $(SOURCES)
+	nasm -DMACHINE_HOMEBREW8088 -O9 -f bin -o bios-homebrew8088.bin -l bios-homebrew8088.lst bios.asm
+
+
 bios-micro8088-noide.rom: bios-micro8088.bin
 	dd if=/dev/zero bs=1k count=40 | tr "\000" "\377" > bios-micro8088-noide.rom
 	cat bios-micro8088.bin >> bios-micro8088-noide.rom
@@ -82,4 +86,4 @@ bios-book8088-xtide-v20.rom: bios-book8088.bin $(XTIDE_300_V20)
 	cat bios-book8088.bin >> bios-book8088-xtide-v20.rom
 
 clean:
-	rm -f bios-micro8088.lst bios-xi8088.lst bios-book8088.lst bios-xt.lst bios-micro8088.bin bios-xi8088.bin bios-book8088.bin bios-xt.bin $(IMAGES)
+	rm -f bios-micro8088.lst bios-xi8088.lst bios-book8088.lst bios-xt.lst bios-homebrew8088.lst bios-micro8088.bin bios-xi8088.bin bios-book8088.bin bios-xt.bin  bios-homebrew8088.bin

--- a/src/config.inc
+++ b/src/config.inc
@@ -29,7 +29,8 @@
 ;%define MACHINE_XI8088			; Xi 8088
 ;%define MACHINE_FE2010A 		; Faraday FE2010A
 ;%define MACHINE_BOOK8088		; Book8088
-;%define MACHINE_XT			; IBM PC/XT or highly compatible board
+;%define MACHINE_XT			    ; IBM PC/XT or highly compatible board
+;%define MACHINE_HOMEBREW8088	; EMM Computers "Homebrew8088" board
 					; FIXME: not implemented yet
 
 ; Settings for Xi 8088
@@ -84,6 +85,16 @@
 %define RAM_TEST_BLOCK	16384		; block size for RAM test
 %define PIT_DELAY			; Use PIT polling for delays
 %endif ; MACHINE_XT
+
+
+%ifdef MACHINE_HOMEBREW8088
+%define	START		0C000h		; FIXME: more ROM for development
+%define MODEL_BYTE	0FEh		; IBM PC/XT
+%define MIN_RAM_SIZE	32		; At least 32 KiB to boot the system
+%define MAX_RAM_SIZE	640		; Scan this much memory during POST
+%define RAM_TEST_BLOCK	16384		; block size for RAM test
+%define PIT_DELAY			; Use PIT polling for delays
+%endif ;MACHINE_HOMEBREW8088
 
 ; Automatic settings based on the machine settings above
 %ifdef AT_RTC or AT_RTC_NVRAM or FLASH_NVRAM

--- a/src/messages.inc
+++ b/src/messages.inc
@@ -35,6 +35,9 @@ msg_copyright	db	0Dh, 0Ah
 %ifdef MACHINE_XT
 		db	"XT 8088"
 %endif ; MACHINE_XT
+%ifdef MACHINE_HOMEBREW8088
+		db	"Homebrew8088"
+%endif ; MACHINE_HOMEBREW8088
 		db	" BIOS, Version "
 		db	VERSION
 		db	". "


### PR DESCRIPTION
The EMM Computers/homebrew8088.com mainboard needs a little special bootstrapping:

* If you're using a NEC V40 CPU card, you need to set its onboard peripherals up
* The keyboard controller needs to be initialized.

This is the same basic code used in the Anonymous BIOS adapted to the board.