### PR TITLE
Further tweaks from Homebrew8088 support testing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,7 @@ XTIDE_320=../xtide_r625/ide_xt-cf-lite_320h.bin
 
 SOURCES=bios.asm macro.inc at_kbc.inc config.inc errno.inc flash.inc floppy1.inc floppy2.inc keyboard.inc misc.inc printer1.inc printer2.inc ps2aux.inc scancode.inc serial1.inc serial2.inc setup.inc sound.inc time1.inc time2.inc video.inc cpu.inc messages.inc inttrace.inc rtc.inc fnt00-7F.inc fnt80-FF.inc
 
-IMAGES=bios-micro8088-noide.rom bios-micro8088-xtide.rom bios-sergey-xt-noide.rom bios-sergey-xt-xtide.rom bios-xi8088-noide.rom bios-xi8088-xtide.rom bios-book8088-xtide.rom bios-book8088-xtide-v20.rom bios-xt.bin
+IMAGES=bios-micro8088-noide.rom bios-micro8088-xtide.rom bios-sergey-xt-noide.rom bios-sergey-xt-xtide.rom bios-xi8088-noide.rom bios-xi8088-xtide.rom bios-book8088-xtide.rom bios-book8088-xtide-v20.rom bios-xt.bin bios-homebrew8088.bin
 FLASH_IMAGE=bios-micro8088-xtide.rom
 
 all: Makefile $(SOURCES) $(IMAGES)

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -22,7 +22,7 @@ XTIDE_320=../xtide_r625/ide_xt-cf-lite_320h.bin
 
 SOURCES=bios.asm macro.inc at_kbc.inc config.inc errno.inc flash.inc floppy1.inc floppy2.inc keyboard.inc misc.inc printer1.inc printer2.inc ps2aux.inc scancode.inc serial1.inc serial2.inc setup.inc sound.inc time1.inc time2.inc video.inc cpu.inc messages.inc inttrace.inc rtc.inc fnt00-7F.inc fnt80-FF.inc
 
-IMAGES=bios-micro8088-noide.rom bios-micro8088-xtide.rom bios-sergey-xt-noide.rom bios-sergey-xt-xtide.rom bios-xi8088-noide.rom bios-xi8088-xtide.rom bios-book8088-xtide.rom bios-book8088-xtide-v20.rom bios-xt.bin
+IMAGES=bios-micro8088-noide.rom bios-micro8088-xtide.rom bios-sergey-xt-noide.rom bios-sergey-xt-xtide.rom bios-xi8088-noide.rom bios-xi8088-xtide.rom bios-book8088-xtide.rom bios-book8088-xtide-v20.rom bios-xt.bin bios-homebrew8088.bin
 FLASH_IMAGE=bios-micro8088-xtide.rom
 
 all: Makefile $(SOURCES) $(IMAGES)

--- a/src/bios.asm
+++ b/src/bios.asm
@@ -686,6 +686,7 @@ init_v40:
 	; Silence the static on the beeper ASAP (with 8088 card)
 	XOR AL, AL
 	OUT 0x61, AL
+
 	jmp post_init_v40
 
 %endif
@@ -790,9 +791,13 @@ cpu_ok:
 
 %ifdef AT_NMI
 	mov	al,0Dh & nmi_disa_mask
-	out	rtc_addr_reg,al		; disable NMI
+	push dx
+	mov dx, rtc_addr_reg
+	out	dx,al		; disable NMI
 	jmp	$+2
-	in	al,rtc_data_reg		; dummy read to keep RTC happy
+	mov dx, rtc_data_reg
+	in	al,dx		; dummy read to keep RTC happy
+	pop dx
 %else ; AT_NMI
 	mov	al,nmi_disable
 	out	nmi_mask_reg,al		; disable NMI

--- a/src/bios.asm
+++ b/src/bios.asm
@@ -686,19 +686,6 @@ init_v40:
 	; Silence the static on the beeper ASAP (with 8088 card)
 	XOR AL, AL
 	OUT 0x61, AL
-
-	mov al, 0xAA
-	out 0x64, al
-	mov cx, 0FFFFh
-	; Rather than delay loops followed by trying to reset the state, let's try just spamming the controller with state-set commands after a reset
-	; hopefully it's less timing sensitive
-	repeatedly_reset_kbc:
-		IN Al, 0x60
-		MOV AL, 0X60		;WRITE COMMAND BYTE TO KEYBOARD CONTROLLER
-		OUT 0X64, AL		;OUT COMMAND PORT
-		MOV AL, 0X41		;PC MODE, ENABLE INTERRUPT
-		OUT 0X60, AL		;OUT DATA PORT
-		LOOP repeatedly_reset_kbc
 	jmp post_init_v40
 
 %endif

--- a/src/comparo.asm
+++ b/src/comparo.asm
@@ -1,0 +1,221 @@
+cpu 186
+org 0x100
+
+
+pic1_reg0	equ	20h
+pic1_reg1	equ	21h
+pit_ch0_reg	equ	40h
+pit_ch1_reg	equ	41h
+pit_ch2_reg	equ	42h
+pit_ctl_reg	equ	43h
+
+
+; How this works:
+; We have the core of the clock calculation logic here, and you can trigger different code to be ran 100x with a "run (operation)" line.
+; It runs the instructions 100x at 3WS and 0WS and times it.
+; While there are differences for all instructions, the idea is we pick a pair that have the same difference (for example, MUL CL and AAM)
+; because if we compare the runtimes of those two instructions that "same difference" will cancel out and effectively neutralize the wait-state factor.
+
+
+
+%macro run 1+
+mov dx, 0xFFF5
+mov al, 0xFF
+out dx, al
+mov si, msg_3_wait
+call print
+
+
+cli				; Disable interrupts for better accuracy
+call io_wait_latch;
+push ax
+%rep 100		; Must be unrolled or it behaves inconsistently on different waitstates IME
+    %1
+    %endrep
+call io_wait_latch;
+sti
+pop bx
+cmp ax, bx
+jae %%second_scan_is_bigger_simple
+sub bx, ax
+
+jmp %%sub_done_simple
+%%second_scan_is_bigger_simple:
+mov cx, 0ffffh
+sub cx, ax
+add bx, cx
+%%sub_done_simple:
+
+push bx	;
+mov ax, bx
+call print_dec
+mov si, endline
+call print
+
+
+
+
+
+mov si, msg_0_wait
+call print
+
+
+mov dx, 0xFFF5
+xor al, al
+out dx, al
+
+
+cli				; Disable interrupts for better accuracy
+call io_wait_latch;
+push ax
+%rep 100		; Must be unrolled or it behaves inconsistently on different waitstates IME
+    %1
+    %endrep
+call io_wait_latch;
+sti
+pop bx
+cmp ax, bx
+jae %%second_scan_is_bigger_simple2
+sub bx, ax
+
+
+jmp %%sub_done_simple2
+%%second_scan_is_bigger_simple2:
+mov cx, 0ffffh
+sub cx, ax
+add bx, cx
+%%sub_done_simple2:
+
+mov ax, bx
+call print_dec
+mov si, endline
+call print
+mov si, difference
+call print
+pop ax
+sub ax, bx
+call print_dec
+%endmacro
+
+mov si, m_aaa
+call print
+run AAA
+mov si, m_aam
+call print
+run AAM
+mov si, m_aas
+call print
+run AAS
+mov si, m_aad
+call print
+run AAD
+
+mov si, m_mul
+call print
+run MUL CL
+
+mov si, m_div
+call print
+run DIV CL
+
+mov si, m_neg
+call print
+run NEG AX
+
+
+
+
+
+int 0x20
+
+
+msg_3_wait db "3-wait mode: ", 0
+msg_0_wait db "   0-wait mode: ", 0
+difference db "   Difference: ", 0
+m_aaa db 0x0d, 0x0a, "AAA - ",0
+m_aam db 0x0d, 0x0a, "AAM - ",0
+m_aas db 0x0d, 0x0a, "AAS - ",0
+m_aad db 0x0d, 0x0a, "AAD - ",0
+m_mul db 0x0d, 0x0a, "MUL CL - ",0
+m_div db 0x0d, 0x0a, "DIV CL - ",0
+m_neg db 0x0d, 0x0a, "NEG AX - ",0
+endline db 0x0d, 0x0a, 0;
+
+
+print:
+	pushf
+	push	ax
+	push	bx
+	push	si
+	push	ds
+	push	cs
+	pop	ds
+	cld
+.1:
+	lodsb
+	or	al,al
+	jz	.exit
+	mov	ah,0Eh
+	mov	bl,0Fh
+	int	10h
+	jmp	.1
+.exit:
+	pop	ds
+	pop	si
+	pop	bx
+	pop	ax
+	popf
+	ret
+
+
+
+print_dec:
+	push	ax
+	push	cx
+	push	dx
+	mov	cx,10		; base = 10
+	call	.print_rec
+	pop	dx
+	pop	cx
+	pop	ax
+	ret
+
+.print_rec:			; print all digits recursively
+	push	dx
+	xor	dx,dx		; DX = 0
+	div	cx		; AX = DX:AX / 10, DX = DX:AX % 10
+	cmp	ax,0
+	je	.below10
+	call	.print_rec	; print number / 10 recursively
+.below10:
+	mov	ax,dx		; reminder is in DX
+	call	print_digit	; print reminder
+	pop	dx
+	ret
+
+io_wait_latch:
+	mov	al,0		; counter 0, latch (00b)
+	pushf			; save current IF
+	cli			; disable interrupts
+	out	pit_ctl_reg,al	; write command to ctc
+	in	al,pit_ch0_reg	; read low byte of counter 0 latch
+	mov	ah,al		; save it
+	in	al,pit_ch0_reg	; read high byte of counter 0 latch
+	popf			; restore IF state
+	xchg	al,ah		; convert endian
+	ret
+print_digit:
+	push	ax
+	push	bx
+	and	al,0Fh
+	add	al,'0'			; convert to ASCII
+	cmp	al,'9'			; less or equal 9?
+	jna	.1
+	add	al,'A'-'9'-1		; a hex digit
+.1:
+	mov	ah,0Eh			; Int 10 function 0Eh - teletype output
+	mov	bl,07h			; just in case we're in graphic mode
+	int	10h
+	pop	bx
+	pop	ax
+	ret

--- a/src/config.inc
+++ b/src/config.inc
@@ -94,6 +94,8 @@
 %define MAX_RAM_SIZE	640		; Scan this much memory during POST
 %define RAM_TEST_BLOCK	16384		; block size for RAM test
 %define PIT_DELAY			; Use PIT polling for delays
+%define AT_KEYBOARD			; The HB8088 KBC is AT-style and can be used with this behaviour without manual initialization
+%define DISABLE_KBD_DURING_INTERRUPTS
 %endif ;MACHINE_HOMEBREW8088
 
 ; Automatic settings based on the machine settings above
@@ -106,3 +108,5 @@
 %define TURBO_MODE			; Has turbo mode
 %endif ; MACHINE_XI8088 or MACHINE_FE2010A
 
+; See floppy1.inc for what value to use for each type of drive.  First digit = drive A, second = drive B
+%define DEFAULT_FLOPPIES 42h

--- a/src/config.inc
+++ b/src/config.inc
@@ -96,10 +96,12 @@
 %define PIT_DELAY			; Use PIT polling for delays
 %define AT_KEYBOARD			; The HB8088 KBC is AT-style and can be used with this behaviour without manual initialization
 %define DISABLE_KBD_DURING_INTERRUPTS
-%define AT_RTC						; Optional: If you're using a RTC card that closely matches the standard here
-%define AT_RTC_AUTODETECT
-%define AT_RTC_CUSTOMPORT	2A0h	
 %endif ;MACHINE_HOMEBREW8088
+
+;%define AT_RTC						; Optional: If you're using a standalone RTC card that uses the same chip as the Xi8088 or FE2010 designs
+;%define AT_RTC_AUTODETECT			;
+;%define AT_RTC_CUSTOMPORT	2A0h	; but you might need to specify a custom port as these cards may not use the default 0x70.
+
 
 ; Automatic settings based on the machine settings above
 %ifndef MACHINE_HOMEBREW8088	; The HB8088 may have a RTC, but it will not have configuration RAM.
@@ -114,4 +116,5 @@
 %endif ; MACHINE_XI8088 or MACHINE_FE2010A
 
 ; See floppy1.inc for what value to use for each type of drive.  First digit = drive A, second = drive B
-%define DEFAULT_FLOPPIES 42h
+; Default "44" is two 1.44M drives.
+%define DEFAULT_FLOPPIES 44h

--- a/src/config.inc
+++ b/src/config.inc
@@ -96,11 +96,10 @@
 %define PIT_DELAY			; Use PIT polling for delays
 %define AT_KEYBOARD			; The HB8088 KBC is AT-style and can be used with this behaviour without manual initialization
 %define DISABLE_KBD_DURING_INTERRUPTS
-%endif ;MACHINE_HOMEBREW8088
-
 ;%define AT_RTC						; Optional: If you're using a standalone RTC card that uses the same chip as the Xi8088 or FE2010 designs
 ;%define AT_RTC_AUTODETECT			;
 ;%define AT_RTC_CUSTOMPORT	2A0h	; but you might need to specify a custom port as these cards may not use the default 0x70.
+%endif ;MACHINE_HOMEBREW8088
 
 
 ; Automatic settings based on the machine settings above

--- a/src/config.inc
+++ b/src/config.inc
@@ -96,12 +96,17 @@
 %define PIT_DELAY			; Use PIT polling for delays
 %define AT_KEYBOARD			; The HB8088 KBC is AT-style and can be used with this behaviour without manual initialization
 %define DISABLE_KBD_DURING_INTERRUPTS
+%define AT_RTC						; Optional: If you're using a RTC card that closely matches the standard here
+%define AT_RTC_AUTODETECT
+%define AT_RTC_CUSTOMPORT	2A0h	
 %endif ;MACHINE_HOMEBREW8088
 
 ; Automatic settings based on the machine settings above
+%ifndef MACHINE_HOMEBREW8088	; The HB8088 may have a RTC, but it will not have configuration RAM.
 %ifdef AT_RTC or AT_RTC_NVRAM or FLASH_NVRAM
 %define BIOS_SETUP			; Include BIOS setup utility
 %endif ; AT_RTC or AT_RTC_NVRAM or FLASH_NVRAM
+%endif ; MACHINE_HOMEBREW8088
 
 ; Note: while Book8088 does have a turbo mode, it is not software controlled
 %ifdef MACHINE_XI8088 or MACHINE_FE2010A

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -187,10 +187,12 @@ detect_cpu:
 	mov	si,msg_est
 	cli				; Disable interrupts for better accuracy
 	call	print
+	
 	call io_wait_latch;
 	push ax
+	xor ax, ax
 	%rep 100		; Must be unrolled or it behaves inconsistently on different waitstates IME
-	 AAA
+	 AAM
 	 %endrep
 	call io_wait_latch;
 	sti
@@ -209,8 +211,9 @@ detect_cpu:
 	cli
 	call io_wait_latch;
 	push ax
+	xor ax, ax
 	%rep 100
-	 AAM
+	 MUL CL
 	 %endrep
 		call io_wait_latch;
 	sti
@@ -242,12 +245,13 @@ detect_cpu:
 	aad	10h			; NEC V20 ignores the argument
 	cmp	al,0Bh			; and always does AL = AL * 0Ah + AH
 	jne .clock_divider_8088
-	mov dx, 002h		;  "Clock Divider" for NEC CPUs.  Value was based on an 8MHz V40: 236 ticks, so the expected value is 8*100*236 = 188800 = 2E180H
-	mov ax, 0E180h		;
+	mov dx, 003h		;  "Clock Divider" for NEC CPUs.  Value was based on an 10MHz V40: ~214 ticks, so the expected value is 1000*214 = 214000 = 343F0H
+	mov ax, 043F0h		;  On the V-series, AAM is faster than MUL (by quite a bit), so a large difference for the clock speed is expected.
 	jmp .clock_divider_set
 	.clock_divider_8088:
-	mov dx, 018h		; "Clock Divider" for 8088 CPUs.  Value was based on a 4.77MHz 8088: ~3398 ticks, so 4.77*100*3398 = 1620846 = 18BB6EH
-	mov ax, 0BB6Eh		;
+	neg bx				;"Clock Divider" for 8088 CPUs.  Value was based on a 4.77MHz 8088: It shows as 65186 ticks, but on an 8088, MUL is faster than AAM
+	mov dx, 0002h		; This means that BX is negative here, so flip the sign and we get 349 ticks... 349 ticks * 477  = 166473 = 28A49H.
+	mov ax, 08A49h		;
 	.clock_divider_set:
 	div bx
 	

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -104,6 +104,33 @@ detect_cpu:
 	jmp	.cpu_freq
 
 .nec_v20:
+	push dx
+	push bx
+	mov dx, 0FFFBh ; Testing premise:  A V40 has on-chip config registers at high-numbered ports, and we can modify them.  On a CPU without these registers, we'd get floating noise.
+				; an on-chip peripheral register we don't use (DMA controller address)
+	in al, dx	; read it, invert all the bits, and write it back
+	xor al, 0FFh
+	mov bl, al
+	out dx, al
+	in al, dx	; read it back and it should store the change
+	cmp al, bl
+	jne .not_v40
+	xor al, 0FFh	; invert again, write it back
+	mov bl, al
+	out dx, al
+
+	in al, dx		;read it back, and it should be back to original.
+	cmp al, bl
+	jne .not_v40
+	pop bx
+	pop dx
+	mov si, msg_cpu_nec_v40
+	call print
+	jmp .cpu_freq
+
+.not_v40:
+	pop bx
+	pop dx
 	mov	si,msg_cpu_nec_v20
 	call	print
 

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -104,33 +104,6 @@ detect_cpu:
 	jmp	.cpu_freq
 
 .nec_v20:
-	push dx
-	push bx
-	mov dx, 0FFFBh ; Testing premise:  A V40 has on-chip config registers at high-numbered ports, and we can modify them.  On a CPU without these registers, we'd get floating noise.
-				; an on-chip peripheral register we don't use (DMA controller address)
-	in al, dx	; read it, invert all the bits, and write it back
-	xor al, 0FFh
-	mov bl, al
-	out dx, al
-	in al, dx	; read it back and it should store the change
-	cmp al, bl
-	jne .not_v40
-	xor al, 0FFh	; invert again, write it back
-	mov bl, al
-	out dx, al
-
-	in al, dx		;read it back, and it should be back to original.
-	cmp al, bl
-	jne .not_v40
-	pop bx
-	pop dx
-	mov si, msg_cpu_nec_v40
-	call print
-	jmp .cpu_freq
-
-.not_v40:
-	pop bx
-	pop dx
 	mov	si,msg_cpu_nec_v20
 	call	print
 
@@ -162,11 +135,14 @@ detect_cpu:
 
 
 .exit:
+%ifdef MACHINE_HOMEBREW8088
 	call .estimate_clock
+%endif
 	pop	si
 	pop	ax
 	ret
 
+%ifdef MACHINE_HOMEBREW8088
 .estimate_clock:
 	push dx
 	push ax
@@ -195,10 +171,11 @@ detect_cpu:
 	sub cx, ax
 	add bx, cx
 	.sub_done:
-;	mov ax, bx			; Keep to see cycles ran if we want to recalculate 7196800
-;	call print_hex
-;	mov ax, 0e20h
-;	int 010h
+	mov ax, bx			; Debugging:  Display the number of clock ticks the loop generated.
+	call print_dec		; Find a constant which when divided by this value produces the expected value (MHz x 100)
+	mov ax, 0e20h		; With emulated hardware, the constant was 006DD080 / 7196800
+	int 010h			; May be easily offset by wait states or inconsistent clock cycles for the loop
+	
 	mov dx, 006Dh		; Clunky estimating logic based on four data points from emulation: 
 	mov ax, 0D080h		; 100x clock is roughly 7196800 / number of ticks that occurred during the run.
 	div bx
@@ -231,6 +208,7 @@ detect_cpu:
 	pop cx
 	pop ax
 	ret
+%endif
 
 ; stack frame after "push bp"
 ; BP - word [BP]

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -163,31 +163,59 @@ detect_cpu:
 
 
 .exit:
-%ifdef MACHINE_HOMEBREW8088 or MACHINE_XI8088
+%ifdef MACHINE_HOMEBREW8088
 	call .estimate_clock
 %endif
 	pop	si
 	pop	ax
 	ret
 
-%ifdef MACHINE_HOMEBREW8088 or MACHINE_XI8088
+%ifdef MACHINE_HOMEBREW8088
 .estimate_clock:
+	; Premise:  Run a cycle that's setup + a loop of 300 "INC AX".  That takes N ticks of the timer, and it includes N1 of actual operations + N2 wait-states from loading the instructions.
+	;           Then run similar setup + a loop of 300 "AAA".  That takes M ticks, which is M1 actual operations + N2 wait states.
+	;			So M - N will remove the "wait state" factor and be how many ticks it took to do "the difference in work between 300 decs and 300 divs"
+	;			Since that's a fixed number of CPU cycles, the M-N value is an inverse of the CPU clock and we can divide by a constant (determined experimentally) to get a reasonable MHz figure
+	;           independent of wait-states.  Note this does not compensate for external variations (i. e. DRAM refresh or a device that seizes the bus)
 	push dx
 	push ax
 	push cx
 	push bx
 	push si
 	mov	si,msg_est
+	cli				; Disable interrupts for better accuracy
 	call	print
 	call io_wait_latch;
 	push ax
-	mov cx, 1000
+	mov cx, 5000
+	XOR AX, AX
+.internal_loop_simple:
+	INC AX; 3 clocks on 8088, 2 clocks on V20 / 1 byte
+	loop .internal_loop_simple
+	call io_wait_latch;
+	sti
+	pop bx
+	cmp ax, bx
+	jae .second_scan_is_bigger_simple
+	sub bx, ax
+	
+	jmp .sub_done_simple
+	.second_scan_is_bigger_simple:
+	mov cx, 0ffffh
+	sub cx, ax
+	add bx, cx
+	.sub_done_simple:
+	push bx	; Save the runtime for the faster instruction
+	cli
+	call io_wait_latch;
+	push ax
+	mov cx, 5000
+	XOR AX, AX
 .internal_loop:
-	add ax, cx
-	dec cx
-	jnz .internal_loop
+	AAA		; 8 clocks on 8088 and 7 clocks on V40 / 1 byte.  V20 databook claims 3 clocks?!
+	loop .internal_loop
 		call io_wait_latch;
-
+	sti
 	pop bx
 	cmp ax, bx
 	jae .second_scan_is_bigger
@@ -199,13 +227,30 @@ detect_cpu:
 	sub cx, ax
 	add bx, cx
 	.sub_done:
-	mov ax, bx			; Debugging:  Display the number of clock ticks the loop generated.
-	call print_dec		; Find a constant which when divided by this value produces the expected value (MHz x 100)
-	mov ax, 0e20h		; With emulated hardware, the constant was 005F4380 / 6243200
-	int 010h			; May be easily offset by wait states or inconsistent clock cycles for the loop
+	pop ax	; pull the count from the simple run
+	sub bx, ax
+	; We'd expect BX to be the amount of clock ticks corresponding to (some large number) more cycles
 
-	mov dx, 005Fh		; Clunky estimating logic based on four data points from emulation: 
-	mov ax, 05480h		; 100x clock is roughly 6243200 / number of ticks that occurred during the run.
+	
+;mov ax, bx			; Refinement tool:  Display the number of clock ticks the loop generated.
+;call print_dec		; Uncomment this code and run it on your machine and it will say things like "244 ticks ~ 8.00MHz"
+;mov si, msg_ticks   ; Calculate (number of ticks) * 100 * (CPU actual MHz)
+;call print			; and place it in DX:AX as the "clock divider" for the CPU type you're using in the code below
+;mov ax, 0e20h	
+;int 010h			
+
+
+	mov	ax,0101h	; Repeat the NEC CPU test
+	aad	10h			; NEC V20 ignores the argument
+	cmp	al,0Bh			; and always does AL = AL * 0Ah + AH
+	jne .clock_divider_8088
+	mov dx, 012h		;  "Clock Divider" for NEC CPUs.  Value was based on an 8MHz V40: ~ 1488 ticks, so the expected value is 8*100*1488 = 1190400 = 122A00h
+	mov ax, 02A00h		;
+	jmp .clock_divider_set
+	.clock_divider_8088:
+	mov dx, 048h		; "Clock Divider" for 8088 CPUs.  Value was based on a 4.77MHz 8088: ~9998 ticks, so 4.77*100*9998 = 4769046 = 48C516h
+	mov ax, 0C516h		;
+	.clock_divider_set:
 	div bx
 	
 	mov bx, 100			; Split to integer and fractional parts

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -208,11 +208,18 @@ detect_cpu:
 
 	mov bx, ax
 	xor ah, ah
-	call print_dec
+	call print_dec		; Integer part
 	mov ax, 0e2eh		; decimal
 	int 010h
-	mov al, bh
 	xor ah, ah
+	mov al, bh
+	cmp al, 10
+	jae .two_digits
+	push ax
+	mov ax, 0e30h		; leading zero
+	int 010h
+	pop ax
+	.two_digits:
 	call print_dec
 	mov si, msg_mhz
 	call print

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -172,11 +172,13 @@ detect_cpu:
 
 %ifdef MACHINE_HOMEBREW8088
 .estimate_clock:
-	; Premise:  Run a cycle that's setup + a loop of 300 "INC AX".  That takes N ticks of the timer, and it includes N1 of actual operations + N2 wait-states from loading the instructions.
-	;           Then run similar setup + a loop of 300 "AAA".  That takes M ticks, which is M1 actual operations + N2 wait states.
-	;			So M - N will remove the "wait state" factor and be how many ticks it took to do "the difference in work between 300 decs and 300 divs"
+	; Premise:  Run a cycle that's setup + a loop of 100 "AAA".  That takes N ticks of the timer, and it includes N1 of actual operations + N2 wait-states from loading the instructions.
+	;           Then run similar setup + a loop of 100 "AAM".  That takes M ticks, which is M1 actual operations + N2 wait states.
+	;			So M - N will remove the "wait state" factor and be how many ticks it took to do "the difference in work between 100 AAAs and 100 AAMs"
 	;			Since that's a fixed number of CPU cycles, the M-N value is an inverse of the CPU clock and we can divide by a constant (determined experimentally) to get a reasonable MHz figure
 	;           independent of wait-states.  Note this does not compensate for external variations (i. e. DRAM refresh or a device that seizes the bus)
+	; It's not hyper-accurate-- it's often off by a few hundred KHz, and it can vary from run to run due to timer noise, but it should be enough to differentiate the major speed grades
+	; A further possible cleanup would be to "bin" the results-- anything below 5MHz as 4.77, anything 7.5-8.5 as 8, etc.
 	push dx
 	push ax
 	push cx
@@ -187,11 +189,9 @@ detect_cpu:
 	call	print
 	call io_wait_latch;
 	push ax
-	mov cx, 5000
-	XOR AX, AX
-.internal_loop_simple:
-	INC AX; 3 clocks on 8088, 2 clocks on V20 / 1 byte
-	loop .internal_loop_simple
+	%rep 100		; Must be unrolled or it behaves inconsistently on different waitstates IME
+	 AAA
+	 %endrep
 	call io_wait_latch;
 	sti
 	pop bx
@@ -209,11 +209,9 @@ detect_cpu:
 	cli
 	call io_wait_latch;
 	push ax
-	mov cx, 5000
-	XOR AX, AX
-.internal_loop:
-	AAA		; 8 clocks on 8088 and 7 clocks on V40 / 1 byte.  V20 databook claims 3 clocks?!
-	loop .internal_loop
+	%rep 100
+	 AAM
+	 %endrep
 		call io_wait_latch;
 	sti
 	pop bx
@@ -244,12 +242,12 @@ detect_cpu:
 	aad	10h			; NEC V20 ignores the argument
 	cmp	al,0Bh			; and always does AL = AL * 0Ah + AH
 	jne .clock_divider_8088
-	mov dx, 012h		;  "Clock Divider" for NEC CPUs.  Value was based on an 8MHz V40: ~ 1488 ticks, so the expected value is 8*100*1488 = 1190400 = 122A00h
-	mov ax, 02A00h		;
+	mov dx, 002h		;  "Clock Divider" for NEC CPUs.  Value was based on an 8MHz V40: 236 ticks, so the expected value is 8*100*236 = 188800 = 2E180H
+	mov ax, 0E180h		;
 	jmp .clock_divider_set
 	.clock_divider_8088:
-	mov dx, 048h		; "Clock Divider" for 8088 CPUs.  Value was based on a 4.77MHz 8088: ~9998 ticks, so 4.77*100*9998 = 4769046 = 48C516h
-	mov ax, 0C516h		;
+	mov dx, 018h		; "Clock Divider" for 8088 CPUs.  Value was based on a 4.77MHz 8088: ~3398 ticks, so 4.77*100*3398 = 1620846 = 18BB6EH
+	mov ax, 0BB6Eh		;
 	.clock_divider_set:
 	div bx
 	

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -159,9 +159,70 @@ detect_cpu:
 	mov	si,msg_cpu_bug
 	call	print
 
+
+
 .exit:
+	call .estimate_clock
 	pop	si
 	pop	ax
+	ret
+
+.estimate_clock:
+	push dx
+	push ax
+	push cx
+	push bx
+	push si
+	mov	si,msg_est
+	call	print
+	call io_wait_latch;
+	push ax
+	mov cx, 1000
+.internal_loop:
+	dec cx
+	cmp cx, 0
+	jnz .internal_loop
+		call io_wait_latch;
+
+	pop bx
+	cmp ax, bx
+	jae .second_scan_is_bigger
+	sub bx, ax
+	
+	jmp .sub_done
+	.second_scan_is_bigger:
+	mov cx, 0ffffh
+	sub cx, ax
+	add bx, cx
+	.sub_done:
+;	mov ax, bx			; Keep to see cycles ran if we want to recalculate 7196800
+;	call print_hex
+;	mov ax, 0e20h
+;	int 010h
+	mov dx, 006Dh		; Clunky estimating logic based on four data points from emulation: 
+	mov ax, 0D080h		; 100x clock is roughly 7196800 / number of ticks that occurred during the run.
+	div bx
+	
+	mov bx, 100			; Split to integer and fractional parts
+	div bl
+
+	mov bx, ax
+	xor ah, ah
+	call print_dec
+	mov ax, 0e2eh		; decimal
+	int 010h
+	mov al, bh
+	xor ah, ah
+	call print_dec
+	mov si, msg_mhz
+	call print
+	mov	si,msg_crlf
+	call	print
+	pop dx
+	pop si
+	pop bx
+	pop cx
+	pop ax
 	ret
 
 ; stack frame after "push bp"

--- a/src/cpu.inc
+++ b/src/cpu.inc
@@ -104,6 +104,34 @@ detect_cpu:
 	jmp	.cpu_freq
 
 .nec_v20:
+	push dx
+	push bx
+	mov dx, 0FFE0h ; Testing premise:  A V40 has on-chip config registers at high-numbered ports, and we can modify them.  The V20 has *some* but not as many.
+				; the V40's seem to be writable as low as 0xFFE0, while the V20's seem scattered and not below FFF0.  FFF0 is the lowest specified register
+				; but the V53 goes down to FFE2 as "reserved".
+	in al, dx	; read it, invert all the bits, and write it back
+	xor al, 0FFh
+	mov bl, al
+	out dx, al
+	in al, dx	; read it back and it should store the change
+	cmp al, bl
+	jne .not_v40
+	xor al, 0FFh	; invert again, write it back
+	mov bl, al
+	out dx, al
+
+	in al, dx		;read it back, and it should be back to original.
+	cmp al, bl
+	jne .not_v40
+	pop bx
+	pop dx
+	mov si, msg_cpu_nec_v40
+	call print
+	jmp .cpu_freq
+
+.not_v40:
+	pop bx
+	pop dx
 	mov	si,msg_cpu_nec_v20
 	call	print
 
@@ -135,14 +163,14 @@ detect_cpu:
 
 
 .exit:
-%ifdef MACHINE_HOMEBREW8088
+%ifdef MACHINE_HOMEBREW8088 or MACHINE_XI8088
 	call .estimate_clock
 %endif
 	pop	si
 	pop	ax
 	ret
 
-%ifdef MACHINE_HOMEBREW8088
+%ifdef MACHINE_HOMEBREW8088 or MACHINE_XI8088
 .estimate_clock:
 	push dx
 	push ax
@@ -155,8 +183,8 @@ detect_cpu:
 	push ax
 	mov cx, 1000
 .internal_loop:
+	add ax, cx
 	dec cx
-	cmp cx, 0
 	jnz .internal_loop
 		call io_wait_latch;
 
@@ -173,11 +201,11 @@ detect_cpu:
 	.sub_done:
 	mov ax, bx			; Debugging:  Display the number of clock ticks the loop generated.
 	call print_dec		; Find a constant which when divided by this value produces the expected value (MHz x 100)
-	mov ax, 0e20h		; With emulated hardware, the constant was 006DD080 / 7196800
+	mov ax, 0e20h		; With emulated hardware, the constant was 005F4380 / 6243200
 	int 010h			; May be easily offset by wait states or inconsistent clock cycles for the loop
-	
-	mov dx, 006Dh		; Clunky estimating logic based on four data points from emulation: 
-	mov ax, 0D080h		; 100x clock is roughly 7196800 / number of ticks that occurred during the run.
+
+	mov dx, 005Fh		; Clunky estimating logic based on four data points from emulation: 
+	mov ax, 05480h		; 100x clock is roughly 6243200 / number of ticks that occurred during the run.
 	div bx
 	
 	mov bx, 100			; Split to integer and fractional parts

--- a/src/delay.inc
+++ b/src/delay.inc
@@ -97,22 +97,6 @@ delay_15us:
 	pop	ax
 	ret
 
-;=========================================================================
-; Latch PIT 0 and read counter
-; Output:
-;	AX = current counter
-;-------------------------------------------------------------------------
-io_wait_latch:
-	mov	al,0		; counter 0, latch (00b)
-	pushf			; save current IF
-	cli			; disable interrupts
-	out	pit_ctl_reg,al	; write command to ctc
-	in	al,pit_ch0_reg	; read low byte of counter 0 latch
-	mov	ah,al		; save it
-	in	al,pit_ch0_reg	; read high byte of counter 0 latch
-	popf			; restore IF state
-	xchg	al,ah		; convert endian
-	ret
 
 %else ; LOOP_DELAY
 
@@ -139,6 +123,24 @@ delay_15us:
 
 %endif ; PIT_DELAY
 %endif ; AT_DELAY
+
+;=========================================================================
+; Latch PIT 0 and read counter
+; Output:
+;	AX = current counter
+;-------------------------------------------------------------------------
+io_wait_latch:
+	mov	al,0		; counter 0, latch (00b)
+	pushf			; save current IF
+	cli			; disable interrupts
+	out	pit_ctl_reg,al	; write command to ctc
+	in	al,pit_ch0_reg	; read low byte of counter 0 latch
+	mov	ah,al		; save it
+	in	al,pit_ch0_reg	; read high byte of counter 0 latch
+	popf			; restore IF state
+	xchg	al,ah		; convert endian
+	ret
+
 
 %if 0
 ;=========================================================================

--- a/src/floppy1.inc
+++ b/src/floppy1.inc
@@ -1653,7 +1653,7 @@ detect_floppy:
 %ifdef BIOS_SETUP
 	call	get_floppy
 %else ; BIOS_SETUP
-	mov	al,DEFAULT_FLOPPIES			; FIXME: fake two 1.44MB floppy drives
+	mov	al,DEFAULT_FLOPPIES	
 %endif ; BIOS_SETUP
 	cmp	al,00h			; No floppy drives?
 	je	.exit
@@ -1678,7 +1678,7 @@ get_drive_type:
 %ifdef BIOS_SETUP
 	call	get_floppy
 %else ; BIOS_SETUP
-	mov	al,DEFAULT_FLOPPIES		; FIXME: fake two 1.44MB floppy drives
+	mov	al,DEFAULT_FLOPPIES
 %endif ; BIOS_SETUP
 	or	dl,dl			; drive 0?
 	jnz	.drive_1		; jump if drive 1 - type in bits 3-0

--- a/src/floppy1.inc
+++ b/src/floppy1.inc
@@ -1653,7 +1653,7 @@ detect_floppy:
 %ifdef BIOS_SETUP
 	call	get_floppy
 %else ; BIOS_SETUP
-	mov	al,44h			; FIXME: fake two 1.44MB floppy drives
+	mov	al,DEFAULT_FLOPPIES			; FIXME: fake two 1.44MB floppy drives
 %endif ; BIOS_SETUP
 	cmp	al,00h			; No floppy drives?
 	je	.exit
@@ -1678,7 +1678,7 @@ get_drive_type:
 %ifdef BIOS_SETUP
 	call	get_floppy
 %else ; BIOS_SETUP
-	mov	al,44h			; FIXME: fake two 1.44MB floppy drives
+	mov	al,DEFAULT_FLOPPIES		; FIXME: fake two 1.44MB floppy drives
 %endif ; BIOS_SETUP
 	or	dl,dl			; drive 0?
 	jnz	.drive_1		; jump if drive 1 - type in bits 3-0

--- a/src/messages.inc
+++ b/src/messages.inc
@@ -68,6 +68,7 @@ msg_cpu_8088_81	db      "Intel 8088 '81 or later, "
 		db      'or OKI-designed 80C88', 00h
 msg_cpu_harris  db      'Harris-designed 80C88', 00h
 msg_cpu_nec_v20 db      'NEC V20', 00h
+msg_cpu_nec_v40 db		'NEC V40', 00h
 msg_fpu_present db      'Intel 8087', 0Dh, 0Ah, 00h
 %ifdef MACHINE_FE2010A
 msg_chipset	db	'Chipset:                    ', 00h

--- a/src/messages.inc
+++ b/src/messages.inc
@@ -61,6 +61,7 @@ msg_clk_turbo	db	'Turbo ', 00h
 %endif ; TURBO_MODE
 msg_est		db      'Estimated Clock:            ',00h
 msg_mhz     db 		"MHz", 00h
+msg_ticks   db      " Ticks " ,247, 00h
 msg_cpu		db      'Main Processor:             ', 00h
 msg_fpu		db      'Mathematics Co-processor:   ', 00h
 msg_cpu_8088_78	db      "Intel 8088 '78", 00h

--- a/src/messages.inc
+++ b/src/messages.inc
@@ -59,6 +59,8 @@ msg_clk_9_55mhz	db	'9.55 MHz ', 00h
 msg_clk_turbo	db	'Turbo ', 00h
 %endif ; MACHINE_FE2010A
 %endif ; TURBO_MODE
+msg_est		db      'Estimated Clock:            ',00h
+msg_mhz     db 		"MHz", 00h
 msg_cpu		db      'Main Processor:             ', 00h
 msg_fpu		db      'Mathematics Co-processor:   ', 00h
 msg_cpu_8088_78	db      "Intel 8088 '78", 00h

--- a/src/rtc.inc
+++ b/src/rtc.inc
@@ -24,8 +24,13 @@
 
 ;-------------------------------------------------------------------------
 ; RTC ports
-rtc_addr_reg	equ	70h	; RTC address port
-rtc_data_reg	equ	71h	; RTC data port
+%ifdef AT_RTC_CUSTOMPORT
+	rtc_addr_reg	equ	AT_RTC_CUSTOMPORT	; RTC address port
+	rtc_data_reg	equ	AT_RTC_CUSTOMPORT+1	; RTC data port
+%else
+	rtc_addr_reg	equ	70h	; RTC address port
+	rtc_data_reg	equ	71h	; RTC data port
+%endif	; No custom port for an AT-like RTC card.
 
 ;-------------------------------------------------------------------------
 ; locations in RTC and NVRAM
@@ -75,12 +80,16 @@ cmos_vrt	equ	80h	; RTC vrt bit (1 = battery is OK)
 ;-------------------------------------------------------------------------
 rtc_read:
 	cli
-	out	rtc_addr_reg,al
+	push dx
+	mov dx, rtc_addr_reg
+	out	dx,al
 	jmp	$+2
 	jmp	$+2
 	jmp	$+2
 	jmp	$+2
-	in	al,rtc_data_reg
+	mov dx, rtc_data_reg
+	in	al,dx
+	pop dx
 	sti
 	ret
 
@@ -94,13 +103,17 @@ rtc_read:
 ;-------------------------------------------------------------------------
 rtc_write:
 	cli
-	out	rtc_addr_reg,al
+	push dx
+	mov dx, rtc_addr_reg
+	out	dx,al
 	jmp	$+2
 	jmp	$+2
 	jmp	$+2
 	jmp	$+2
 	xchg	ah,al
-	out	rtc_data_reg,al
+	mov dx, rtc_data_reg
+	out	dx,al
+	pop dx
 	xchg	ah,al
 	sti
 	ret


### PR DESCRIPTION

1.  The Homebrew8088 build target now uses the built-in AT keyboard support, which seems to work and also supports the lock LEDs.  The old logic, I think, basically convinced the AT-style controller to behave XT-like enough that other XT BIOSes could handle it.
2. I set up the logic to talk to the RTC to use "out DX, AL" and made the port configurable.  This supports cards like https://www.tindie.com/products/spark2k06/rtc-isa-8-bits-very-low-profile-2/ which could be set to a port other than 0x70.
3. The definition for hard coded floppy drives is now in config.inc, so it's easier to customize.
4. Code to differentiate between the NEC V20 and V40 for the power-up message.  (This is based on experimentation rather than a spec; the V40 seems to allow you to write and read back ports in the 0xFFE0-FFF0 range, while the V20 doesn't.)
5. An attempt to estimate CPU clock speed, just because modern BIOSes usually show it.  I would not at all be insulted if this was discarded or optional, since it's a both imprecise and sort of a space hog, but it is fun.  The io_wait_latch code was made available outside specific defines, since it's used here to get data from the timer.