### PR TITLE
Comment fixes

### DIFF
--- a/src/bios.asm
+++ b/src/bios.asm
@@ -91,7 +91,7 @@ iochk_status	equ	40h	; ~IOCHK status - 1 = ~IOCHK NMI signalled
 
 %ifdef MACHINE_XT or MACHINE_FE2010A
 ; Port 62h - 8255 PPI Port C - Read only
-ppi_pc_reg	equ	62h	; 8255 PPI port C I/O registerA
+ppi_pc_reg	equ	62h	; 8255 PPI port C I/O register
 ; XT DIP switches 1-4 (read when bit 3 of PPI Port B is 1)
 sw_post_loop	equ	01h	; XT DIP switch 1 - 1 = Loop on POST
 sw_fpu_present	equ	02h	; XT DIP switch 2 - 1 = FPU present
@@ -140,7 +140,7 @@ ppi_cwd_reg	equ	63h	; 8255 PPI control word register
 ppi_cwd_value	equ	99h	; 8255 PPI control word value for IBM XT:
 				; Port A - mode 0 (simple I/O), input
 				; Port B - mode 0 (simple I/O), output
-				; Port C - output
+				; Port C - input
 %endif ; MACHINE_XT
 
 post_reg	equ	80h	; POST status output port

--- a/src/delay.inc
+++ b/src/delay.inc
@@ -67,7 +67,7 @@ delay_15us:
 ; - Latch the PIT and draw down the countdown total on each read.
 ; - Exit when countdown underflows.
 ;
-; Note: Mode 3 (Square Wave) decements the readable counter by 2, so the
+; Note: Mode 3 (Square Wave) decrements the readable counter by 2, so the
 ; effective frequency of the counter is actually 2,386,360 Hz.
 ;
 ; Contributed by @640-KB (under GPL-3.0 license)


### PR DESCRIPTION
I found a few issues in comments that I was able to fix. The PR contains no functional changes.

Apart from two simple typo fixes, there is also a meaningful change in one comment: PPI port C is in fact set up for input, not output.

References:
- https://github.com/skiselev/8088_bios/blob/master/src/bios.asm#L94, where the port C is read, not written to
- ppi_cwd_value is 99h, not 90h (and bits 0 and 3 decide whether port C is input or output), see attached screenshot from 8255 data sheet
- attached screenshot from IBM PC technical reference

![image](https://github.com/user-attachments/assets/b004049d-f550-42b1-98ab-8dfaed259bdb)
![image](https://github.com/user-attachments/assets/ab7c77db-14f7-48ed-b0d5-d4566a6bdd86)
